### PR TITLE
suggested gas tip from eth reader to enjoy multiple nodes tolerance and a bunch of formatting corrections

### DIFF
--- a/cmd/util/pre_process.go
+++ b/cmd/util/pre_process.go
@@ -1,20 +1,19 @@
 package util
 
 import (
-	"context"
 	"fmt"
-	types2 "github.com/tranvictor/jarvis/accounts/types"
-	"github.com/tranvictor/jarvis/cmd/ethutil"
-	"github.com/tranvictor/jarvis/config/state"
-	"github.com/tranvictor/jarvis/networks"
 	"math/big"
 	"strings"
 
 	"github.com/spf13/cobra"
+
 	"github.com/tranvictor/jarvis/accounts"
+	types2 "github.com/tranvictor/jarvis/accounts/types"
 	. "github.com/tranvictor/jarvis/common"
 	"github.com/tranvictor/jarvis/config"
+	"github.com/tranvictor/jarvis/config/state"
 	"github.com/tranvictor/jarvis/msig"
+	"github.com/tranvictor/jarvis/networks"
 	"github.com/tranvictor/jarvis/util"
 )
 
@@ -125,10 +124,14 @@ func CommonTxPreprocess(cmd *cobra.Command, args []string) (err error) {
 			}
 		}
 		if count == 0 {
-			return fmt.Errorf("You don't have any wallet which is this multisig signer. Please jarvis wallet add to add the wallet.")
+			return fmt.Errorf(
+				"You don't have any wallet which is this multisig signer. Please jarvis wallet add to add the wallet.",
+			)
 		}
 		if count != 1 {
-			return fmt.Errorf("You have many wallets that are this multisig signers. Please specify only 1.")
+			return fmt.Errorf(
+				"You have many wallets that are this multisig signers. Please specify only 1.",
+			)
 		}
 		config.FromAcc = acc
 		config.From = acc.Address
@@ -167,15 +170,19 @@ func CommonTxPreprocess(cmd *cobra.Command, args []string) (err error) {
 			return fmt.Errorf("getting nonce failed: %w", err)
 		}
 	}
-	eClient := ethutil.MustGetETHClient()
 	if config.TxType == "" {
-		if CheckDynamicFeeTxAvailable(eClient) {
+		dynamicFeeAvailable, err := reader.CheckDynamicFeeTxAvailable()
+		if err != nil {
+			return fmt.Errorf("checking if chain has dynamic fee feature failed: %w", err)
+		}
+
+		if dynamicFeeAvailable {
 			config.TxType = config.TxTypeDynamicFee
 		}
 	}
 
 	if config.TipGas == 0 && config.TxType == config.TxTypeDynamicFee {
-		suggestTip, err := eClient.SuggestGasTipCap(context.Background())
+		suggestTip, err := reader.GetSuggestedGasTipCap()
 		if err != nil {
 			return fmt.Errorf("getting tip gas failed: %w", err)
 		}

--- a/common/transaction.go
+++ b/common/transaction.go
@@ -1,16 +1,15 @@
 package common
 
 import (
-	"context"
-	"fmt"
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/ethclient"
+
 	"github.com/tranvictor/jarvis/config"
 	"github.com/tranvictor/jarvis/networks"
-	"math/big"
 )
 
 // RawTxToHash returns valid hex data of a transaction to
@@ -19,7 +18,14 @@ func RawTxToHash(data string) string {
 	return crypto.Keccak256Hash(hexutil.MustDecode(data)).Hex()
 }
 
-func BuildExactTx(nonce uint64, to string, ethAmount *big.Int, gasLimit uint64, priceGwei float64, data []byte) (tx *types.Transaction) {
+func BuildExactTx(
+	nonce uint64,
+	to string,
+	ethAmount *big.Int,
+	gasLimit uint64,
+	priceGwei float64,
+	data []byte,
+) (tx *types.Transaction) {
 	toAddress := common.HexToAddress(to)
 	gasPrice := GweiToWei(priceGwei)
 	tipInt := GweiToWei(config.TipGas)
@@ -47,18 +53,38 @@ func BuildExactTx(nonce uint64, to string, ethAmount *big.Int, gasLimit uint64, 
 	}
 }
 
-func BuildTx(nonce uint64, to string, ethAmount float64, gasLimit uint64, priceGwei float64, data []byte) (tx *types.Transaction) {
+func BuildTx(
+	nonce uint64,
+	to string,
+	ethAmount float64,
+	gasLimit uint64,
+	priceGwei float64,
+	data []byte,
+) (tx *types.Transaction) {
 	amount := FloatToBigInt(ethAmount, 18)
 	return BuildExactTx(nonce, to, amount, gasLimit, priceGwei, data)
 }
 
-func BuildExactSendETHTx(nonce uint64, to string, ethAmount *big.Int, gasLimit uint64, priceGwei float64,
-	tipGas float64, txType string, chainID int64,
+func BuildExactSendETHTx(
+	nonce uint64,
+	to string,
+	ethAmount *big.Int,
+	gasLimit uint64,
+	priceGwei float64,
+	tipGas float64,
+	txType string,
+	chainID int64,
 ) (tx *types.Transaction) {
 	return BuildExactTx(nonce, to, ethAmount, gasLimit, priceGwei, []byte{})
 }
 
-func BuildContractCreationTx(nonce uint64, ethAmount *big.Int, gasLimit uint64, priceGwei float64, data []byte) (tx *types.Transaction) {
+func BuildContractCreationTx(
+	nonce uint64,
+	ethAmount *big.Int,
+	gasLimit uint64,
+	priceGwei float64,
+	data []byte,
+) (tx *types.Transaction) {
 	gasPrice := GweiToWei(priceGwei)
 	tipInt := GweiToWei(config.TipGas)
 	chainIDInt := big.NewInt(networks.CurrentNetwork().GetChainID())
@@ -81,16 +107,4 @@ func BuildContractCreationTx(nonce uint64, ethAmount *big.Int, gasLimit uint64, 
 			Data:     data,
 		})
 	}
-}
-
-// CheckDynamicFeeTxAvailable use to detect if current network that connect via node url is support dynamic fee tx,
-// this is done by a trick where we check if block info contain baseFee > 0, that may not always work but should enough
-// for now.
-func CheckDynamicFeeTxAvailable(ethclient *ethclient.Client) bool {
-	block, err := ethclient.BlockByNumber(context.Background(), nil)
-	if err != nil {
-		fmt.Printf("couldn't get block by number: %s\n", err)
-		return false
-	}
-	return block.BaseFee() != nil && block.BaseFee().Cmp(common.Big0) > 0
 }

--- a/util/reader/ethereum_node.go
+++ b/util/reader/ethereum_node.go
@@ -5,13 +5,19 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/core/types"
+
 	"github.com/tranvictor/jarvis/common"
 )
 
 type EthereumNode interface {
 	NodeName() string
 	NodeURL() string
-	EstimateGas(from, to string, priceGwei float64, value *big.Int, data []byte) (gas uint64, err error)
+	EstimateGas(
+		from, to string,
+		priceGwei float64,
+		value *big.Int,
+		data []byte,
+	) (gas uint64, err error)
 	GetCode(address string) (code []byte, err error)
 	GetBalance(address string) (balance *big.Int, err error)
 	GetMinedNonce(address string) (nonce uint64, err error)
@@ -20,7 +26,15 @@ type EthereumNode interface {
 	TransactionByHash(txHash string) (tx *common.Transaction, isPending bool, err error)
 	// Call(result interface{}, method string, args ...interface{}) error
 	GetGasPriceSuggestion() (*big.Int, error)
-	ReadContractToBytes(atBlock int64, from string, caddr string, abi *abi.ABI, method string, args ...interface{}) ([]byte, error)
+	SuggestedGasTipCap() (*big.Int, error)
+	ReadContractToBytes(
+		atBlock int64,
+		from string,
+		caddr string,
+		abi *abi.ABI,
+		method string,
+		args ...interface{},
+	) ([]byte, error)
 	StorageAt(atBlock int64, caddr string, slot string) ([]byte, error)
 	HeaderByNumber(number int64) (*types.Header, error)
 	GetLogs(fromBlock, toBlock int, addresses []string, topic string) ([]types.Log, error)

--- a/util/reader/one_node_reader.go
+++ b/util/reader/one_node_reader.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
+
 	. "github.com/tranvictor/jarvis/common"
 )
 
@@ -214,6 +215,18 @@ func (self *OneNodeReader) HeaderByNumber(number int64) (*types.Header, error) {
 	return ethcli.HeaderByNumber(timeout, numberBig)
 }
 
+func (self *OneNodeReader) SuggestedGasTipCap() (*big.Int, error) {
+	ethcli, err := self.EthClient()
+	if err != nil {
+		return nil, err
+	}
+
+	timeout, cancel := context.WithTimeout(context.Background(), TIMEOUT)
+	defer cancel()
+
+	return ethcli.SuggestGasTipCap(timeout)
+}
+
 func (self *OneNodeReader) GetLogs(fromBlock, toBlock int, addresses []string, topic string) ([]types.Log, error) {
 	ethcli, err := self.EthClient()
 	if err != nil {
@@ -230,7 +243,7 @@ func (self *OneNodeReader) GetLogs(fromBlock, toBlock int, addresses []string, t
 	}
 	q.Addresses = HexToAddresses(addresses)
 	q.Topics = [][]common.Hash{
-		[]common.Hash{HexToHash(topic)},
+		{HexToHash(topic)},
 	}
 
 	timeout, cancel := context.WithTimeout(context.Background(), TIMEOUT)

--- a/util/reader/reader.go
+++ b/util/reader/reader.go
@@ -13,13 +13,12 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
+
 	. "github.com/tranvictor/jarvis/common"
 	. "github.com/tranvictor/jarvis/util/explorers"
 )
 
-var (
-	DEFAULT_ADDRESS string = "0x0000000000000000000000000000000000000000"
-)
+var DEFAULT_ADDRESS string = "0x0000000000000000000000000000000000000000"
 
 const (
 	DEFAULT_ETHERSCAN_APIKEY string = "UBB257TI824FC7HUSPT66KZUMGBPRN3IWV"
@@ -63,9 +62,14 @@ type estimateGasResult struct {
 	Error error
 }
 
-func (self *EthReader) EstimateExactGas(from, to string, priceGwei float64, value *big.Int, data []byte) (uint64, error) {
+func (self *EthReader) EstimateExactGas(
+	from, to string,
+	priceGwei float64,
+	value *big.Int,
+	data []byte,
+) (uint64, error) {
 	resCh := make(chan estimateGasResult, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			gas, err := n.EstimateGas(from, to, priceGwei, value, data)
@@ -86,7 +90,11 @@ func (self *EthReader) EstimateExactGas(from, to string, priceGwei float64, valu
 	return 0, fmt.Errorf("Couldn't read from any nodes: %s", errorInfo(errs))
 }
 
-func (self *EthReader) EstimateGas(from, to string, priceGwei, value float64, data []byte) (uint64, error) {
+func (self *EthReader) EstimateGas(
+	from, to string,
+	priceGwei, value float64,
+	data []byte,
+) (uint64, error) {
 	return self.EstimateExactGas(from, to, priceGwei, FloatToBigInt(value, 18), data)
 }
 
@@ -97,7 +105,7 @@ type getCodeResponse struct {
 
 func (self *EthReader) GetCode(address string) (code []byte, err error) {
 	resCh := make(chan getCodeResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			code, err := n.GetCode(address)
@@ -245,7 +253,7 @@ type getGasSuggestionResponse struct {
 
 func (self *EthReader) GetGasPriceWeiSuggestion() (*big.Int, error) {
 	resCh := make(chan getGasSuggestionResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			price, err := n.GetGasPriceSuggestion()
@@ -273,7 +281,7 @@ type getBalanceResponse struct {
 
 func (self *EthReader) GetBalance(address string) (balance *big.Int, err error) {
 	resCh := make(chan getBalanceResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			balance, err := n.GetBalance(address)
@@ -301,7 +309,7 @@ type getNonceResponse struct {
 
 func (self *EthReader) GetMinedNonce(address string) (nonce uint64, err error) {
 	resCh := make(chan getNonceResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			nonce, err := n.GetMinedNonce(address)
@@ -324,7 +332,7 @@ func (self *EthReader) GetMinedNonce(address string) (nonce uint64, err error) {
 
 func (self *EthReader) GetPendingNonce(address string) (nonce uint64, err error) {
 	resCh := make(chan getNonceResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			nonce, err := n.GetPendingNonce(address)
@@ -352,7 +360,7 @@ type transactionReceiptResponse struct {
 
 func (self *EthReader) TransactionReceipt(txHash string) (receipt *types.Receipt, err error) {
 	resCh := make(chan transactionReceiptResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			receipt, err := n.TransactionReceipt(txHash)
@@ -379,9 +387,11 @@ type transactionByHashResponse struct {
 	Error     error
 }
 
-func (self *EthReader) TransactionByHash(txHash string) (tx *Transaction, isPending bool, err error) {
+func (self *EthReader) TransactionByHash(
+	txHash string,
+) (tx *Transaction, isPending bool, err error) {
 	resCh := make(chan transactionByHashResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			tx, ispending, err := n.TransactionByHash(txHash)
@@ -408,9 +418,16 @@ type readContractToBytesResponse struct {
 	Error error
 }
 
-func (self *EthReader) ReadContractToBytes(atBlock int64, from string, caddr string, abi *abi.ABI, method string, args ...interface{}) ([]byte, error) {
+func (self *EthReader) ReadContractToBytes(
+	atBlock int64,
+	from string,
+	caddr string,
+	abi *abi.ABI,
+	method string,
+	args ...interface{},
+) ([]byte, error) {
 	resCh := make(chan readContractToBytesResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			data, err := n.ReadContractToBytes(atBlock, from, caddr, abi, method, args...)
@@ -481,7 +498,7 @@ func (self *EthReader) ImplementationOf(atBlock int64, caddr string) (common.Add
 
 func (self *EthReader) StorageAt(atBlock int64, caddr string, slot string) ([]byte, error) {
 	resCh := make(chan readContractToBytesResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			data, err := n.StorageAt(atBlock, caddr, slot)
@@ -502,7 +519,14 @@ func (self *EthReader) StorageAt(atBlock int64, caddr string, slot string) ([]by
 	return nil, fmt.Errorf("Couldn't read from any nodes: %s", errorInfo(errs))
 }
 
-func (self *EthReader) ReadHistoryContractWithABI(atBlock int64, result interface{}, caddr string, abi *abi.ABI, method string, args ...interface{}) error {
+func (self *EthReader) ReadHistoryContractWithABI(
+	atBlock int64,
+	result interface{},
+	caddr string,
+	abi *abi.ABI,
+	method string,
+	args ...interface{},
+) error {
 	responseBytes, err := self.ReadContractToBytes(
 		int64(atBlock), DEFAULT_ADDRESS, caddr, abi, method, args...)
 	if err != nil {
@@ -511,7 +535,14 @@ func (self *EthReader) ReadHistoryContractWithABI(atBlock int64, result interfac
 	return abi.UnpackIntoInterface(result, method, responseBytes)
 }
 
-func (self *EthReader) ReadContractWithABIAndFrom(result interface{}, from string, caddr string, abi *abi.ABI, method string, args ...interface{}) error {
+func (self *EthReader) ReadContractWithABIAndFrom(
+	result interface{},
+	from string,
+	caddr string,
+	abi *abi.ABI,
+	method string,
+	args ...interface{},
+) error {
 	responseBytes, err := self.ReadContractToBytes(-1, from, caddr, abi, method, args...)
 	if err != nil {
 		return err
@@ -519,7 +550,13 @@ func (self *EthReader) ReadContractWithABIAndFrom(result interface{}, from strin
 	return abi.UnpackIntoInterface(result, method, responseBytes)
 }
 
-func (self *EthReader) ReadContractWithABI(result interface{}, caddr string, abi *abi.ABI, method string, args ...interface{}) error {
+func (self *EthReader) ReadContractWithABI(
+	result interface{},
+	caddr string,
+	abi *abi.ABI,
+	method string,
+	args ...interface{},
+) error {
 	responseBytes, err := self.ReadContractToBytes(-1, DEFAULT_ADDRESS, caddr, abi, method, args...)
 	if err != nil {
 		return err
@@ -527,7 +564,13 @@ func (self *EthReader) ReadContractWithABI(result interface{}, caddr string, abi
 	return abi.UnpackIntoInterface(result, method, responseBytes)
 }
 
-func (self *EthReader) ReadHistoryContract(atBlock int64, result interface{}, caddr string, method string, args ...interface{}) error {
+func (self *EthReader) ReadHistoryContract(
+	atBlock int64,
+	result interface{},
+	caddr string,
+	method string,
+	args ...interface{},
+) error {
 	abi, err := self.GetABI(caddr)
 	if err != nil {
 		return err
@@ -535,7 +578,12 @@ func (self *EthReader) ReadHistoryContract(atBlock int64, result interface{}, ca
 	return self.ReadHistoryContractWithABI(atBlock, result, caddr, abi, method, args...)
 }
 
-func (self *EthReader) ReadContract(result interface{}, caddr string, method string, args ...interface{}) error {
+func (self *EthReader) ReadContract(
+	result interface{},
+	caddr string,
+	method string,
+	args ...interface{},
+) error {
 	abi, err := self.GetABI(caddr)
 	if err != nil {
 		return err
@@ -543,10 +591,21 @@ func (self *EthReader) ReadContract(result interface{}, caddr string, method str
 	return self.ReadContractWithABI(result, caddr, abi, method, args...)
 }
 
-func (self *EthReader) HistoryERC20Balance(atBlock int64, caddr string, user string) (*big.Int, error) {
+func (self *EthReader) HistoryERC20Balance(
+	atBlock int64,
+	caddr string,
+	user string,
+) (*big.Int, error) {
 	abi := GetERC20ABI()
 	result := big.NewInt(0)
-	err := self.ReadHistoryContractWithABI(atBlock, &result, caddr, abi, "balanceOf", HexToAddress(user))
+	err := self.ReadHistoryContractWithABI(
+		atBlock,
+		&result,
+		caddr,
+		abi,
+		"balanceOf",
+		HexToAddress(user),
+	)
 	return result, err
 }
 
@@ -585,7 +644,7 @@ type headerByNumberResponse struct {
 
 func (self *EthReader) HeaderByNumber(number int64) (*types.Header, error) {
 	resCh := make(chan headerByNumberResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			header, err := n.HeaderByNumber(number)
@@ -606,7 +665,53 @@ func (self *EthReader) HeaderByNumber(number int64) (*types.Header, error) {
 	return nil, fmt.Errorf("Couldn't read from any nodes: %s", errorInfo(errs))
 }
 
-func (self *EthReader) HistoryERC20Allowance(atBlock int64, caddr string, owner string, spender string) (*big.Int, error) {
+// CheckDynamicFeeTxAvailable use to detect if current network that connect via node url is support dynamic fee tx,
+// this is done by a trick where we check if block info contain baseFee > 0, that may not always work but should enough
+// for now.
+func (self *EthReader) CheckDynamicFeeTxAvailable() (bool, error) {
+	header, err := self.HeaderByNumber(-1) // getting latest block header
+	if err != nil {
+		return false, err
+	}
+
+	return header.BaseFee != nil && header.BaseFee.Cmp(common.Big0) > 0, nil
+}
+
+type getSuggestedGasTipCapResponse struct {
+	GasTip *big.Int
+	Error  error
+}
+
+func (self *EthReader) GetSuggestedGasTipCap() (*big.Int, error) {
+	resCh := make(chan getSuggestedGasTipCapResponse, len(self.nodes))
+	for i := range self.nodes {
+		n := self.nodes[i]
+		go func() {
+			gasTip, err := n.SuggestedGasTipCap()
+			resCh <- getSuggestedGasTipCapResponse{
+				GasTip: gasTip,
+				Error:  wrapError(err, n.NodeName()),
+			}
+		}()
+	}
+
+	errs := []error{}
+	for i := 0; i < len(self.nodes); i++ {
+		result := <-resCh
+		if result.Error == nil {
+			return result.GasTip, result.Error
+		}
+		errs = append(errs, result.Error)
+	}
+	return nil, fmt.Errorf("Couldn't read from any nodes: %s", errorInfo(errs))
+}
+
+func (self *EthReader) HistoryERC20Allowance(
+	atBlock int64,
+	caddr string,
+	owner string,
+	spender string,
+) (*big.Int, error) {
 	abi := GetERC20ABI()
 	result := big.NewInt(0)
 	err := self.ReadHistoryContractWithABI(
@@ -619,7 +724,11 @@ func (self *EthReader) HistoryERC20Allowance(atBlock int64, caddr string, owner 
 	return result, err
 }
 
-func (self *EthReader) ERC20Allowance(caddr string, owner string, spender string) (*big.Int, error) {
+func (self *EthReader) ERC20Allowance(
+	caddr string,
+	owner string,
+	spender string,
+) (*big.Int, error) {
 	abi := GetERC20ABI()
 	result := big.NewInt(0)
 	err := self.ReadContractWithABI(
@@ -631,7 +740,10 @@ func (self *EthReader) ERC20Allowance(caddr string, owner string, spender string
 	return result, err
 }
 
-func (self *EthReader) AddressFromContract(contract string, method string) (*common.Address, error) {
+func (self *EthReader) AddressFromContract(
+	contract string,
+	method string,
+) (*common.Address, error) {
 	result := common.Address{}
 	err := self.ReadContract(&result, contract, method)
 	if err != nil {
@@ -646,9 +758,13 @@ type getLogsResponse struct {
 }
 
 // if toBlock < 0, it will query to the latest block
-func (self *EthReader) GetLogs(fromBlock, toBlock int, addresses []string, topic string) ([]types.Log, error) {
+func (self *EthReader) GetLogs(
+	fromBlock, toBlock int,
+	addresses []string,
+	topic string,
+) ([]types.Log, error) {
 	resCh := make(chan getLogsResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			logs, err := n.GetLogs(fromBlock, toBlock, addresses, topic)
@@ -676,7 +792,7 @@ type getBlockResponse struct {
 
 func (self *EthReader) CurrentBlock() (uint64, error) {
 	resCh := make(chan getBlockResponse, len(self.nodes))
-	for i, _ := range self.nodes {
+	for i := range self.nodes {
 		n := self.nodes[i]
 		go func() {
 			block, err := n.CurrentBlock()


### PR DESCRIPTION
In this PR I suggest to interact with ethereum nodes in Jarvis way. Instead of calling directly ethClient, we implement functions with `util/reader/*` so we don't have to worry about initiating ethClient instances as well as how to query from multiple nodes in parallel and choose the fastest response from them.